### PR TITLE
fix fallback to default encoding

### DIFF
--- a/lib/csv_format_guesser.rb
+++ b/lib/csv_format_guesser.rb
@@ -32,8 +32,8 @@ class CsvFormatGuesser
     try_encoding_with_fallback!
   rescue Encoding::UndefinedConversionError => e
     @encoding = 'ISO-8859-1' if @encoding == 'ISO-8859-7'
-   rescue => e
-     @encoding ||= DEFAULT_ENCODING
+  rescue => e
+    @encoding = DEFAULT_ENCODING
   end
 
   def try_encoding_with_fallback!


### PR DESCRIPTION
In case `try_encoding_with_fallback!` threw an exception the encoding was not changed which lead to `readlines` to throw the same error.